### PR TITLE
Fix bug : the computation of pages count for pagination is incorrect.

### DIFF
--- a/tools/bazar/presentation/javascripts/bazar-list-dynamic.js
+++ b/tools/bazar/presentation/javascripts/bazar-list-dynamic.js
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
       },
       pages() {
         if (this.pagination <= 0) return []
-        let pagesCount = Math.floor(this.filteredEntries.length / parseInt(this.pagination)) + 1
+        let pagesCount = Math.ceil(this.filteredEntries.length / parseInt(this.pagination))
         let start = 0, end = pagesCount - 1        
         let pages = [this.currentPage - 2, this.currentPage - 1, this.currentPage, this.currentPage + 1, this.currentPage + 2]
         pages = pages.filter(page => page >= start && page <= end)


### PR DESCRIPTION
Bad computation of pages number in pagination mechanism.
Old formula floor (nb pages/pagination) +1
new formula ceil (nb pages/pagination)
ex : 6 pages / 3 pages per pagination gives 3 (last page is empty) with the 1st formula and 2 (all pages filled) with the 2nd one
## Description of pull request / Description de la demande d'ajout
Describe what it does / Expliquer ce que cela fait
Issue references (if exists)/ Demande associée (si elle existe)
