### PR TITLE
Correct bug for account created before mail activation process exists

### DIFF
--- a/tools/login/actions/LoginAction.php
+++ b/tools/login/actions/LoginAction.php
@@ -204,6 +204,8 @@ class LoginAction extends YesWikiAction
             {            
             	$vMessage = "Your account must be activated first. ";
             
+            	$this->userManager->inactivateUser ($user["name"], "", true);
+            
             	if ($this->userManager->sendActivationLink ($user["name"]))
 				{	            
 	            	$vMessage .= "A mail was sent to you with the instruction to activate you account. ";


### PR DESCRIPTION
Add the activation status property in the triple table by forcing account inactivation

