### PR TITLE
Remove warning in User.php that cause bug (pollute output) in debug mode

### DIFF
--- a/includes/entities/User.php
+++ b/includes/entities/User.php
@@ -80,7 +80,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, ArrayAc
         return (in_array($offset, self::PROPS_LIST));
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset) : mixed
     {
         if (!$this->offsetExists($offset)) {
             throw new UserNotExistingOffset("Not existing $offset in User!");


### PR DESCRIPTION
Remove warning generated in debug mode that pollute output for ajax request :

Deprecated: Return type of YesWiki\Core\Entity\User::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/yves/Developpement/YesWiki/doryphore-dev/www/includes/entities/User.php on line 83

add mixed as a return type for public function offsetGet($offset) : mixed
