### PR TITLE
Correct correctly the hash bug

### DIFF
--- a/tools/bazar/presentation/javascripts/entries-index-dynamic.js
+++ b/tools/bazar/presentation/javascripts/entries-index-dynamic.js
@@ -238,7 +238,8 @@ const load = (domElement) => {
             if (val) this.currentSort = val
           } else if (hashKey && hashValue && filter) {
             filter.flattenNodes.forEach((node) => {
-              if (hashValue.includes(node.value)) node.checked = true
+              var filterValues = hashValue.split (",");
+			        if (filterValues.includes(node.value)) node.checked = true        
             })
           }
         })


### PR DESCRIPTION
veveqnv
il y a 8 minutes

Salut, je me suis rendu compte que j'avais perdu la correction du bug du hash dans l'adresse qui ne marchait pas. Mais en regardant la proposition de correction sur le wiki dev actuel je me suis rendu compte qu'il y a une erreur dans le traitement.

Ligne 241 de bazar/presentation/javascripts/entries-index-dynamic.js

la correction proposée utilise la fonction includes du type string. 

if (hashValue.includes(node.value)) node.checked = true

C'est une erreur qui pourra provoquer des bugs : 

"3,18" includes "1" doit retourner vrai parce qu'on recherche 1 dans la chaine et que 18 en contient un : on doit comparer les numéros.

Il faut d'abord splitter sur les "," puis utiliser includes du type array 

var filterValues = hashValue.split (",");
if (filterValues.includes(node.value)) node.checked = true

## Description of pull request / Description de la demande d'ajout

Describe what it does / Expliquer ce que cela fait
Issue references (if exists)/ Demande associée (si elle existe)
